### PR TITLE
NXCT-42 Add cfssl tooling to nuxeo-apb-base

### DIFF
--- a/nuxeo-apb-base/Dockerfile
+++ b/nuxeo-apb-base/Dockerfile
@@ -1,3 +1,9 @@
 FROM ansibleplaybookbundle/apb-base
 
 RUN yum install -y openssl && yum clean all
+
+ADD requirements.yml /opt/apb/actions/requirements.yml
+ADD run_role_on_localhost.yml /opt/apb/actions/run_role_on_localhost.yml
+
+RUN ansible-galaxy install -r /opt/apb/actions/requirements.yml && \
+    ansible-playbook /opt/apb/actions/run_role_on_localhost.yml -e "ROLE=andrewrothstein.cfssl"

--- a/nuxeo-apb-base/README.md
+++ b/nuxeo-apb-base/README.md
@@ -1,4 +1,4 @@
 # nuxeo-apb-base
 
-This is a base image used to create several Nuxeo [Ansible Playbook Bundle](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle). This base image includes the openssl tooling needed by several Nuxeo APBs to manage certificates.
+This is a base image used to create several Nuxeo [Ansible Playbook Bundle](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle). This base image includes the openssl and cfssl tooling needed by several Nuxeo APBs to manage certificates.
 

--- a/nuxeo-apb-base/requirements.yml
+++ b/nuxeo-apb-base/requirements.yml
@@ -1,0 +1,2 @@
+- src: andrewrothstein.cfssl
+  version: v2.0.2

--- a/nuxeo-apb-base/run_role_on_localhost.yml
+++ b/nuxeo-apb-base/run_role_on_localhost.yml
@@ -1,0 +1,8 @@
+---
+# Play:   run_role.yml
+# Usage:  ansible-playbook run_role.yml -e "ROLE=<role>"
+
+- hosts:  'localhost'
+
+  roles:
+  - { role: '{{ROLE}}' }


### PR DESCRIPTION
Add cfssl tooling to nuxeo-apb-base to support certificate management in several Nuxeo APBs